### PR TITLE
Cursor pagination for GET /jobs/{id}/job-applications

### DIFF
--- a/src/main/resources/PetSitter/petsitter-api.yml
+++ b/src/main/resources/PetSitter/petsitter-api.yml
@@ -537,6 +537,20 @@ paths:
     get:
       summary: List Applications for Job
       operationId: viewApplicationsForJob
+      parameters:
+        - name: limit
+          in: query
+          description: The maximum number of results to return.
+          schema:
+            type: integer
+            default: 20
+            maximum: 100
+        - name: cursor
+          in: query
+          description: |
+            Use the cursor from the response to access more results.
+          schema:
+            type: string
       tags:
         - Jobs
       responses:


### PR DESCRIPTION
There will be a situation when a lot of applications per job are exist. So it wold be nace to have some kind of pagination in such cases. 